### PR TITLE
Add rakaia to general tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [SpatialAgent](https://www.biorxiv.org/content/10.1101/2025.04.03.646459v1.full.pdf) - An autonomous AI agent for spatial biology
 - [LazySlide](https://github.com/rendeirolab/LazySlide) - Framework for whole slide image (WSI) analysis
 - [pasta](https://robinsonlabuzh.github.io/pasta/00-home.html) - Point pattern and lattice data analysis from Robinson lab
+- [rakaia](https://github.com/camlab-bioml/rakaia) - Scalable interactive visualization and analysis of spatial omics including spatial transcriptomics, in the browser ([Website](https://rakaia.io/))
 
 
 ### Nextflow / Pipelines


### PR DESCRIPTION
I would like to add our application [rakaia](https://github.com/camlab-bioml/rakaia) under the `General tools`, as it provides a browser interface for users to interactively visualise and analyse spatial transcriptomics datasets. More information about those features can be found here: https://rakaia.io/docs/spatial/