### PR TITLE
Add FlashDeconv to Cell Deconvolution section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@
 - [Cell2location](https://github.com/BayraktarLab/cell2location) - Mapping scRNA-seq to spatial data
 - [SPOTlight](https://github.com/MarcElosua/SPOTlight) - Seeded NMF regression to deconvolute spatial spots
 - [CARD](https://github.com/YingMa0107/CARD) - Spatially informed cell-type deconvolution
+- [FlashDeconv](https://github.com/cafferychen777/flashdeconv) - High-performance deconvolution using randomized sketching, achieves linear O(N) scaling for Visium HD and other high-resolution platforms
 
 ### Differential Expression
 


### PR DESCRIPTION
## Summary

Add FlashDeconv to the Cell Deconvolution section.

**FlashDeconv** is a high-performance spatial transcriptomics deconvolution tool using structure-preserving randomized sketching:

- **Linear O(N) scaling**: Processes 1M spots in ~3 minutes
- **Designed for high-resolution platforms**: Visium HD, Stereo-seq, etc.
- **Scanpy-style API**: Easy integration with scverse ecosystem

**Links:**
- GitHub: https://github.com/cafferychen777/flashdeconv
- Paper: https://doi.org/10.64898/2025.12.22.696108
- PyPI: https://pypi.org/project/flashdeconv/