### PR TITLE
Add ChatSpatial to General Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - [SpaVAE](https://github.com/ttgump/spaVAE) - All-purpose tool for dimension reduction, visualization, clustering, batch integration, denoising, differential expression, spatial interpolation, and resolution enhancement
 - [sopa](https://github.com/gustaveroussy/sopa) - Spatial omics processing and analysis
 - [SpatialAgent](https://www.biorxiv.org/content/10.1101/2025.04.03.646459v1.full.pdf) - An autonomous AI agent for spatial biology
+- [ChatSpatial](https://github.com/cafferychen777/ChatSpatial) - MCP server enabling spatial transcriptomics analysis via natural language, integrating 60+ methods including SpaGCN, Cell2location, LIANA+, CellRank for Visium, Xenium, MERFISH | [Docs](https://cafferychen777.github.io/ChatSpatial/) | [PyPI](https://pypi.org/project/chatspatial/)
 - [LazySlide](https://github.com/rendeirolab/LazySlide) - Framework for whole slide image (WSI) analysis
 - [pasta](https://robinsonlabuzh.github.io/pasta/00-home.html) - Point pattern and lattice data analysis from Robinson lab
 - [rakaia](https://github.com/camlab-bioml/rakaia) - Scalable interactive visualization and analysis of spatial omics including spatial transcriptomics, in the browser ([Website](https://rakaia.io/))


### PR DESCRIPTION
## Summary
Add [ChatSpatial](https://github.com/cafferychen777/ChatSpatial) to the General Tools section.

ChatSpatial is an MCP (Model Context Protocol) server that enables spatial transcriptomics analysis via natural language interaction. It integrates 60+ analysis methods including:

- **Spatial domains**: SpaGCN, STAGATE, GraphST
- **Deconvolution**: Cell2location, RCTD, DestVI, Tangram, CARD
- **Cell communication**: LIANA+, CellPhoneDB, CellChat
- **Trajectory**: CellRank, Palantir, scVelo

Supports Visium, Xenium, MERFISH, Slide-seq, and other platforms.

- Documentation: https://cafferychen777.github.io/ChatSpatial/
- PyPI: https://pypi.org/project/chatspatial/